### PR TITLE
Launch app in full screen reliably

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -16,6 +16,7 @@ function createWindow() {
     width: 1400,
     height: 900,
     fullscreen: true, // Launch in fullscreen
+    fullscreenable: true,
     webPreferences: {
       nodeIntegration: false,
       contextIsolation: true,
@@ -25,6 +26,10 @@ function createWindow() {
     titleBarStyle: 'hiddenInset',
     backgroundColor: '#1a1a1a',
     title: 'Flicktionary'
+  });
+
+  mainWindow.once('ready-to-show', () => {
+    mainWindow!.setFullScreen(true);
   });
 
   if (process.env.NODE_ENV === 'development') {


### PR DESCRIPTION
## Summary
- ensure the BrowserWindow is fullscreenable
- explicitly set fullscreen when ready to show

## Testing
- `npm run build:renderer`
- `npm run build:main`


------
https://chatgpt.com/codex/tasks/task_e_68688e8f0f6c8323a7f77129c5b6bdc3