### PR TITLE
Add icon support

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,8 +8,9 @@
     "dev": "webpack serve --mode development",
     "build:renderer": "webpack --mode production",
     "build:main": "tsc -p tsconfig.electron.json",
-    "build": "npm run build:renderer && npm run build:main && npm run copy:preload",
+    "build": "npm run build:renderer && npm run build:main && npm run copy:preload && npm run copy:assets",
     "copy:preload": "cp src/main/preload.js dist/preload.js",
+    "copy:assets": "cp -r png dist/png",
     "electron": "electron .",
     "dist": "npm run build && electron-builder"
   },

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -16,6 +16,7 @@ function createWindow() {
     width: 1400,
     height: 900,
     fullscreen: true, // Launch in fullscreen
+    icon: path.join(__dirname, 'png', 'flicktionary_logo.png'),
     webPreferences: {
       nodeIntegration: false,
       contextIsolation: true,


### PR DESCRIPTION
## Summary
- add custom icon to BrowserWindow
- copy image assets during build

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68688e7a7f7c8323a2c5d77085655da6