### PR TITLE
Fix initial video playback rendering

### DIFF
--- a/src/renderer/components/VideoPlayer.tsx
+++ b/src/renderer/components/VideoPlayer.tsx
@@ -38,12 +38,16 @@ const VideoPlayer: React.FC<VideoPlayerProps> = ({
     playerRef.current = player;
 
     // Set up video segment
-    const startTime = timestampToSeconds(beginTimestamp) - 1;
+    // Clamp to zero in case the segment begins near the start of the video
+    const startTime = Math.max(0, timestampToSeconds(beginTimestamp) - 1);
     const endTime = timestampToSeconds(endTimestamp) + 1;
 
     player.ready(() => {
-      player.currentTime(startTime);
-      
+      // Wait until metadata is loaded before seeking to avoid blank playback
+      player.one('loadedmetadata', () => {
+        player.currentTime(startTime);
+      });
+
       player.on('timeupdate', () => {
         const currentTime = player.currentTime();
         if (currentTime && currentTime >= endTime) {


### PR DESCRIPTION
## Summary
- fix `VideoPlayer` first render black screen
- clamp first timestamp to zero and wait for `loadedmetadata` before seeking

## Testing
- `npm run build:renderer`
- `npm run build:main`


------
https://chatgpt.com/codex/tasks/task_e_68688f23f404832382b074727781bf62