### PR TITLE
Add copy assets script and devServer static path

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,8 +8,9 @@
     "dev": "webpack serve --mode development",
     "build:renderer": "webpack --mode production",
     "build:main": "tsc -p tsconfig.electron.json",
-    "build": "npm run build:renderer && npm run build:main && npm run copy:preload",
+    "build": "npm run build:renderer && npm run build:main && npm run copy:preload && npm run copy:assets",
     "copy:preload": "cp src/main/preload.js dist/preload.js",
+    "copy:assets": "cp -r png dist/png",
     "electron": "electron .",
     "dist": "npm run build && electron-builder"
   },

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -12,6 +12,12 @@ const ffmpegPath = require('ffmpeg-static');
 ffmpeg.setFfmpegPath(ffmpegPath);
 
 function createWindow() {
+  const iconPath = path.join(__dirname, 'png', 'flicktionary_logo.png');
+
+  if (process.platform === 'darwin') {
+    app.dock.setIcon(iconPath);
+  }
+
   mainWindow = new BrowserWindow({
     width: 1400,
     height: 900,
@@ -24,7 +30,8 @@ function createWindow() {
     },
     titleBarStyle: 'hiddenInset',
     backgroundColor: '#1a1a1a',
-    title: 'Flicktionary'
+    title: 'Flicktionary',
+    icon: iconPath
   });
 
   if (process.env.NODE_ENV === 'development') {

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -11,6 +11,10 @@ const ffmpeg = require('fluent-ffmpeg');
 const ffmpegPath = require('ffmpeg-static');
 ffmpeg.setFfmpegPath(ffmpegPath);
 
+if (process.platform === 'darwin') {
+  app.setName('Flicktionary');
+}
+
 function createWindow() {
   const iconPath = path.join(__dirname, 'png', 'flicktionary_logo.png');
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -35,9 +35,10 @@ module.exports = {
     })
   ],
   devServer: {
-    static: {
-      directory: path.join(__dirname, 'dist')
-    },
+    static: [
+      { directory: path.join(__dirname, 'dist') },
+      { directory: path.join(__dirname, 'png') }
+    ],
     compress: true,
     port: 9000
   }


### PR DESCRIPTION
## Summary
- add `copy:assets` npm script to copy png files
- call `copy:assets` in the main build script
- serve png assets from dev server

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68688e7954dc832381724c3d9ccdde8d