### PR TITLE
Add Gemini button for vocabulary prompt

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -109,6 +109,15 @@ ipcMain.handle('save-api-key', async (event, apiKey) => {
   return { success: true };
 });
 
+ipcMain.handle('read-file', async (_event, filePath) => {
+  try {
+    const content = fs.readFileSync(path.join(app.getAppPath(), filePath), 'utf8');
+    return { success: true, content };
+  } catch (error: any) {
+    return { success: false, error: error.message };
+  }
+});
+
 ipcMain.handle('open-external', async (_event, url) => {
   await shell.openExternal(url);
   return { success: true };

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -1,4 +1,4 @@
-import { app, BrowserWindow, ipcMain, dialog } from 'electron';
+import { app, BrowserWindow, ipcMain, dialog, shell } from 'electron';
 import * as path from 'path';
 import * as fs from 'fs';
 import Store from 'electron-store';
@@ -106,5 +106,10 @@ ipcMain.handle('get-api-key', async () => {
 
 ipcMain.handle('save-api-key', async (event, apiKey) => {
   store.set('gemini-api-key', apiKey);
+  return { success: true };
+});
+
+ipcMain.handle('open-external', async (_event, url) => {
+  await shell.openExternal(url);
   return { success: true };
 });

--- a/src/main/preload.js
+++ b/src/main/preload.js
@@ -6,5 +6,6 @@ contextBridge.exposeInMainWorld('electronAPI', {
   extractSubtitles: (videoPath) => ipcRenderer.invoke('extract-subtitles', videoPath),
   getApiKey: () => ipcRenderer.invoke('get-api-key'),
   saveApiKey: (apiKey) => ipcRenderer.invoke('save-api-key', apiKey),
-  openExternal: (url) => ipcRenderer.invoke('open-external', url)
+  openExternal: (url) => ipcRenderer.invoke('open-external', url),
+  readFile: (filePath) => ipcRenderer.invoke('read-file', filePath)
 });

--- a/src/main/preload.js
+++ b/src/main/preload.js
@@ -5,5 +5,6 @@ contextBridge.exposeInMainWorld('electronAPI', {
   getFilePath: (fileData) => ipcRenderer.invoke('get-file-path', fileData),
   extractSubtitles: (videoPath) => ipcRenderer.invoke('extract-subtitles', videoPath),
   getApiKey: () => ipcRenderer.invoke('get-api-key'),
-  saveApiKey: (apiKey) => ipcRenderer.invoke('save-api-key', apiKey)
+  saveApiKey: (apiKey) => ipcRenderer.invoke('save-api-key', apiKey),
+  openExternal: (url) => ipcRenderer.invoke('open-external', url)
 });

--- a/src/renderer/components/FileUpload.tsx
+++ b/src/renderer/components/FileUpload.tsx
@@ -118,12 +118,14 @@ const FileUpload: React.FC<FileUploadProps> = ({
 
   const loadPrompt = async (): Promise<string> => {
     try {
-      const response = await fetch('./prompt.txt');
-      return await response.text();
-    } catch (error) {
-      // Fallback prompt if file not found
-      return `Your task is to act as an expert linguist and cultural analyst. I will provide you with a full transcript of movie subtitles. You must perform a comprehensive analysis of this entire transcript to identify and explain all language elements that would be difficult for a proficient (C1-level) non-native English speaker, particularly one whose native language is Turkish, to understand...`;
+      const result = await window.electronAPI.readFile("prompt.txt");
+      if (result.success && result.content) {
+        return result.content;
+      }
+    } catch {
+      // Ignore and fall back to default prompt
     }
+    return `Your task is to act as an expert linguist and cultural analyst. I will provide you with a full transcript of movie subtitles. You must perform a comprehensive analysis of this entire transcript to identify and explain all language elements that would be difficult for a proficient (C1-level) non-native English speaker, particularly one whose native language is Turkish, to understand...`;
   };
 
   const handleGenerateVocabulary = async () => {

--- a/src/renderer/global.d.ts
+++ b/src/renderer/global.d.ts
@@ -9,6 +9,7 @@ declare global {
       getApiKey: () => Promise<string | null>;
       saveApiKey: (apiKey: string) => Promise<{ success: boolean }>;
       openExternal: (url: string) => Promise<{ success: boolean }>;
+      readFile: (filePath: string) => Promise<{ success: boolean; content?: string; error?: string }>;
     };
   }
 }

--- a/src/renderer/global.d.ts
+++ b/src/renderer/global.d.ts
@@ -8,6 +8,7 @@ declare global {
       extractSubtitles: (videoPath: string) => Promise<{ success: boolean; content?: string; error?: string }>;
       getApiKey: () => Promise<string | null>;
       saveApiKey: (apiKey: string) => Promise<{ success: boolean }>;
+      openExternal: (url: string) => Promise<{ success: boolean }>;
     };
   }
 }


### PR DESCRIPTION
## Summary
- integrate Gemini workflow
- copy subtitles + prompt text to clipboard and open Gemini in the browser

## Testing
- `npm run build:main`
- `npm run build:renderer`


------
https://chatgpt.com/codex/tasks/task_e_68688e5b8cfc8323899e6c2306e9b905