### PR TITLE
Fix video player initialization guard

### DIFF
--- a/src/renderer/components/VideoPlayer.tsx
+++ b/src/renderer/components/VideoPlayer.tsx
@@ -24,7 +24,7 @@ const VideoPlayer: React.FC<VideoPlayerProps> = ({
   };
 
   useEffect(() => {
-    if (!videoRef.current) return;
+    if (!videoRef.current || !videoUrl) return;
 
     // Initialize video.js player
     const player = videojs(videoRef.current, {


### PR DESCRIPTION
## Summary
- ensure VideoPlayer doesn't initialize with missing refs or URL

## Testing
- `npm install`
- `npm run build:renderer`
- `npm run build:main`


------
https://chatgpt.com/codex/tasks/task_e_6868918a3fc0832393b43ada3b348b71