### PR TITLE
Adjust Next button behavior in vocabulary session

### DIFF
--- a/src/renderer/components/VocabularySession.tsx
+++ b/src/renderer/components/VocabularySession.tsx
@@ -70,6 +70,10 @@ const VocabularySession: React.FC<VocabularySessionProps> = ({
     return result?.known;
   };
 
+  const isCurrentAnswered = () => {
+    return results.some(r => r.word.term === currentWord.term);
+  };
+
   return (
     <div className="vocabulary-session">
       <div className="progress-bar">
@@ -136,9 +140,12 @@ const VocabularySession: React.FC<VocabularySessionProps> = ({
             >
               ← Previous
             </button>
-            <button 
+            <button
               onClick={() => handleNavigation('next')}
-              disabled={currentIndex === sessionData.vocabularyWords.length - 1}
+              disabled={
+                currentIndex === sessionData.vocabularyWords.length - 1 ||
+                !isCurrentAnswered()
+              }
               className="nav-btn"
             >
               Next →


### PR DESCRIPTION
## Summary
- disable "Next" button unless the current word has been answered
- add helper to check whether current word is answered

## Testing
- `npm run build:renderer`
- `npm run build:main`

------
https://chatgpt.com/codex/tasks/task_e_68689861b7e483239bcb214fd7bf095d