### PR TITLE
Display subtitles on video playback

### DIFF
--- a/src/renderer/components/VideoPlayer.tsx
+++ b/src/renderer/components/VideoPlayer.tsx
@@ -4,14 +4,16 @@ import Player from 'video.js/dist/types/player';
 
 interface VideoPlayerProps {
   videoUrl: string;
+  subtitleUrl: string;
   beginTimestamp: string;
   endTimestamp: string;
 }
 
-const VideoPlayer: React.FC<VideoPlayerProps> = ({ 
-  videoUrl, 
-  beginTimestamp, 
-  endTimestamp 
+const VideoPlayer: React.FC<VideoPlayerProps> = ({
+  videoUrl,
+  subtitleUrl,
+  beginTimestamp,
+  endTimestamp
 }) => {
   const videoRef = useRef<HTMLVideoElement>(null);
   const playerRef = useRef<Player | null>(null);
@@ -61,6 +63,24 @@ const VideoPlayer: React.FC<VideoPlayerProps> = ({
       }
     };
   }, [videoUrl, beginTimestamp, endTimestamp]);
+
+  useEffect(() => {
+    const player = playerRef.current;
+    if (player && subtitleUrl) {
+      const track = player.addRemoteTextTrack(
+        {
+          kind: 'subtitles',
+          src: subtitleUrl,
+          label: 'English',
+          default: true
+        },
+        false
+      );
+      return () => {
+        player.removeRemoteTextTrack(track);
+      };
+    }
+  }, [subtitleUrl]);
 
   return (
     <div className="video-player-wrapper">

--- a/src/renderer/styles/main.css
+++ b/src/renderer/styles/main.css
@@ -473,6 +473,11 @@ body {
   background: #4f9cf9;
 }
 
+/* Larger subtitles */
+.video-js .vjs-text-track-display div {
+  font-size: 1.2em;
+}
+
 /* Scrollbar Styles */
 ::-webkit-scrollbar {
   width: 10px;


### PR DESCRIPTION
## Summary
- show subtitles during vocabulary sessions
- generate WebVTT subtitle blobs from SRT files
- pass subtitle track into VideoPlayer component
- enlarge subtitle text
- ensure first video plays smoothly by adding track without reinitializing player
- fix duplicate subtitles by removing duplicate <track> element

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6868976fa7a483238e8256b188d65ffe