### PR TITLE
Auto-save vocabulary results

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -70,17 +70,18 @@ app.on('activate', () => {
 });
 
 // IPC handlers
-ipcMain.handle('save-results', async (event, results) => {
-  const { filePath } = await dialog.showSaveDialog({
-    filters: [{ name: 'JSON', extensions: ['json'] }],
-    defaultPath: 'vocabulary-results.json'
-  });
-
-  if (filePath) {
-    fs.writeFileSync(filePath, JSON.stringify(results, null, 2));
-    return { success: true, path: filePath };
+ipcMain.handle('save-results', async (_event, results, videoFileName) => {
+  const rootDir = app.getAppPath();
+  const processedDir = path.join(rootDir, 'processed');
+  if (!fs.existsSync(processedDir)) {
+    fs.mkdirSync(processedDir, { recursive: true });
   }
-  return { success: false };
+
+  const baseName = path.parse(videoFileName).name;
+  const filePath = path.join(processedDir, `words_for_${baseName}.json`);
+
+  fs.writeFileSync(filePath, JSON.stringify(results, null, 2));
+  return { success: true, path: filePath };
 });
 
 ipcMain.handle('get-file-path', async (event, fileData) => {

--- a/src/main/preload.js
+++ b/src/main/preload.js
@@ -1,7 +1,8 @@
 const { contextBridge, ipcRenderer } = require('electron');
 
 contextBridge.exposeInMainWorld('electronAPI', {
-  saveResults: (results) => ipcRenderer.invoke('save-results', results),
+  saveResults: (results, videoFileName) =>
+    ipcRenderer.invoke('save-results', results, videoFileName),
   getFilePath: (fileData) => ipcRenderer.invoke('get-file-path', fileData),
   extractSubtitles: (videoPath) => ipcRenderer.invoke('extract-subtitles', videoPath),
   getApiKey: () => ipcRenderer.invoke('get-api-key'),

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -26,7 +26,11 @@ const App: React.FC = () => {
     // Save results
     if (window.electronAPI) {
       try {
-        const result = await window.electronAPI.saveResults(unknownWords);
+        const videoName = sessionData?.videoFile.name || 'video';
+        const result = await window.electronAPI.saveResults(
+          unknownWords,
+          videoName
+        );
         if (result.success) {
           alert(`Results saved to: ${result.path}`);
         }

--- a/src/renderer/global.d.ts
+++ b/src/renderer/global.d.ts
@@ -3,7 +3,10 @@ export {};
 declare global {
   interface Window {
     electronAPI: {
-      saveResults: (results: any[]) => Promise<{ success: boolean; path?: string }>;
+      saveResults: (
+        results: any[],
+        videoFileName: string
+      ) => Promise<{ success: boolean; path?: string }>;
       getFilePath: (fileData: ArrayBuffer) => Promise<string>;
       extractSubtitles: (videoPath: string) => Promise<{ success: boolean; content?: string; error?: string }>;
       getApiKey: () => Promise<string | null>;


### PR DESCRIPTION
## Summary
- save vocabulary JSONs automatically in a `processed` folder
- include the movie filename when saving
- expose updated electron API to renderer

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68689cfb38208323b524f257eca23346