### PR TITLE
Improve session layout

### DIFF
--- a/src/renderer/styles/main.css
+++ b/src/renderer/styles/main.css
@@ -322,6 +322,7 @@ body {
 
 .word-details {
   flex: 1;
+  padding-top: 20px; /* space below progress bar */
 }
 
 .term {
@@ -408,7 +409,7 @@ body {
 .navigation-buttons {
   display: flex;
   gap: 15px;
-  margin-top: 20px;
+  margin-top: 50px; /* more space from response buttons */
 }
 
 .nav-btn {


### PR DESCRIPTION
## Summary
- add top padding to word details so text isn't jammed against the top
- increase spacing between response and navigation buttons for better layout

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6868a102c5888323a72325d2f4be3b22