### PR TITLE
Add support for more video formats

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -84,9 +84,17 @@ ipcMain.handle('save-results', async (_event, results, videoFileName) => {
   return { success: true, path: filePath };
 });
 
-ipcMain.handle('get-file-path', async (event, fileData) => {
-  // Save temporary file and return path for video player
-  const tempPath = path.join(app.getPath('temp'), `video-${Date.now()}.mp4`);
+ipcMain.handle('get-file-path', async (event, fileData, fileName) => {
+  // Save temporary file with the same extension as the uploaded file
+  let ext = '.mp4';
+  if (typeof fileName === 'string') {
+    const parsed = path.extname(fileName);
+    if (parsed) {
+      ext = parsed;
+    }
+  }
+
+  const tempPath = path.join(app.getPath('temp'), `video-${Date.now()}${ext}`);
   fs.writeFileSync(tempPath, Buffer.from(fileData));
   return tempPath;
 });

--- a/src/main/preload.js
+++ b/src/main/preload.js
@@ -3,7 +3,8 @@ const { contextBridge, ipcRenderer } = require('electron');
 contextBridge.exposeInMainWorld('electronAPI', {
   saveResults: (results, videoFileName) =>
     ipcRenderer.invoke('save-results', results, videoFileName),
-  getFilePath: (fileData) => ipcRenderer.invoke('get-file-path', fileData),
+  getFilePath: (fileData, fileName) =>
+    ipcRenderer.invoke('get-file-path', fileData, fileName),
   extractSubtitles: (videoPath) => ipcRenderer.invoke('extract-subtitles', videoPath),
   getApiKey: () => ipcRenderer.invoke('get-api-key'),
   saveApiKey: (apiKey) => ipcRenderer.invoke('save-api-key', apiKey),

--- a/src/renderer/components/FileUpload.tsx
+++ b/src/renderer/components/FileUpload.tsx
@@ -37,7 +37,7 @@ const FileUpload: React.FC<FileUploadProps> = ({
       setVideoFile(file);
       // Create temporary file path for subtitle extraction
       const arrayBuffer = await file.arrayBuffer();
-      const filePath = await window.electronAPI.getFilePath(arrayBuffer);
+      const filePath = await window.electronAPI.getFilePath(arrayBuffer, file.name);
       videoFileRef.current = filePath;
       updateSessionData(file, subtitleFile, vocabularyWords);
     }

--- a/src/renderer/components/VideoPlayer.tsx
+++ b/src/renderer/components/VideoPlayer.tsx
@@ -4,6 +4,7 @@ import Player from 'video.js/dist/types/player';
 
 interface VideoPlayerProps {
   videoUrl: string;
+  videoType: string;
   subtitleUrl: string;
   beginTimestamp: string;
   endTimestamp: string;
@@ -11,6 +12,7 @@ interface VideoPlayerProps {
 
 const VideoPlayer: React.FC<VideoPlayerProps> = ({
   videoUrl,
+  videoType,
   subtitleUrl,
   beginTimestamp,
   endTimestamp
@@ -74,7 +76,7 @@ const VideoPlayer: React.FC<VideoPlayerProps> = ({
         className="video-js vjs-default-skin vjs-big-play-centered"
         playsInline
       >
-        <source src={videoUrl} type="video/mp4" />
+        <source src={videoUrl} type={videoType || 'video/mp4'} />
         {subtitleUrl && (
           <track
             kind="subtitles"

--- a/src/renderer/components/VocabularySession.tsx
+++ b/src/renderer/components/VocabularySession.tsx
@@ -118,6 +118,7 @@ const VocabularySession: React.FC<VocabularySessionProps> = ({
         <div className="video-section">
           <VideoPlayer
             videoUrl={videoUrl}
+            videoType={sessionData.videoFile.type}
             subtitleUrl={subtitleUrl}
             beginTimestamp={currentWord.beginTimestamp}
             endTimestamp={currentWord.endTimestamp}

--- a/src/renderer/global.d.ts
+++ b/src/renderer/global.d.ts
@@ -7,7 +7,7 @@ declare global {
         results: any[],
         videoFileName: string
       ) => Promise<{ success: boolean; path?: string }>;
-      getFilePath: (fileData: ArrayBuffer) => Promise<string>;
+      getFilePath: (fileData: ArrayBuffer, fileName: string) => Promise<string>;
       extractSubtitles: (videoPath: string) => Promise<{ success: boolean; content?: string; error?: string }>;
       getApiKey: () => Promise<string | null>;
       saveApiKey: (apiKey: string) => Promise<{ success: boolean }>;


### PR DESCRIPTION
## Summary
- allow temp file extension to match uploaded file
- expose file name parameter in preload and type declarations
- store filename when uploading and hand it to Electron API
- keep MIME type when playing video

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6868a37d779083239172ed17267aad3f