### PR TITLE
Enable multiple video formats

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -84,9 +84,9 @@ ipcMain.handle('save-results', async (_event, results, videoFileName) => {
   return { success: true, path: filePath };
 });
 
-ipcMain.handle('get-file-path', async (event, fileData) => {
-  // Save temporary file and return path for video player
-  const tempPath = path.join(app.getPath('temp'), `video-${Date.now()}.mp4`);
+ipcMain.handle('get-file-path', async (_event, fileData, fileName) => {
+  const ext = path.extname(fileName || '').toLowerCase() || '.mp4';
+  const tempPath = path.join(app.getPath('temp'), `video-${Date.now()}${ext}`);
   fs.writeFileSync(tempPath, Buffer.from(fileData));
   return tempPath;
 });

--- a/src/main/preload.js
+++ b/src/main/preload.js
@@ -3,7 +3,8 @@ const { contextBridge, ipcRenderer } = require('electron');
 contextBridge.exposeInMainWorld('electronAPI', {
   saveResults: (results, videoFileName) =>
     ipcRenderer.invoke('save-results', results, videoFileName),
-  getFilePath: (fileData) => ipcRenderer.invoke('get-file-path', fileData),
+  getFilePath: (fileData, fileName) =>
+    ipcRenderer.invoke('get-file-path', fileData, fileName),
   extractSubtitles: (videoPath) => ipcRenderer.invoke('extract-subtitles', videoPath),
   getApiKey: () => ipcRenderer.invoke('get-api-key'),
   saveApiKey: (apiKey) => ipcRenderer.invoke('save-api-key', apiKey),

--- a/src/renderer/components/FileUpload.tsx
+++ b/src/renderer/components/FileUpload.tsx
@@ -37,7 +37,7 @@ const FileUpload: React.FC<FileUploadProps> = ({
       setVideoFile(file);
       // Create temporary file path for subtitle extraction
       const arrayBuffer = await file.arrayBuffer();
-      const filePath = await window.electronAPI.getFilePath(arrayBuffer);
+      const filePath = await window.electronAPI.getFilePath(arrayBuffer, file.name);
       videoFileRef.current = filePath;
       updateSessionData(file, subtitleFile, vocabularyWords);
     }

--- a/src/renderer/components/VideoPlayer.tsx
+++ b/src/renderer/components/VideoPlayer.tsx
@@ -25,6 +25,22 @@ const VideoPlayer: React.FC<VideoPlayerProps> = ({
     return hours * 3600 + minutes * 60 + seconds + (ms ? parseInt(ms) / 1000 : 0);
   };
 
+  const getMimeType = (url: string): string => {
+    const ext = url.split('.').pop()?.toLowerCase();
+    switch (ext) {
+      case 'mp4':
+        return 'video/mp4';
+      case 'mkv':
+        return 'video/x-matroska';
+      case 'webm':
+        return 'video/webm';
+      case 'ogg':
+        return 'video/ogg';
+      default:
+        return 'video/*';
+    }
+  };
+
   useEffect(() => {
     if (!videoRef.current || !videoUrl) return;
 
@@ -74,7 +90,7 @@ const VideoPlayer: React.FC<VideoPlayerProps> = ({
         className="video-js vjs-default-skin vjs-big-play-centered"
         playsInline
       >
-        <source src={videoUrl} type="video/mp4" />
+        <source src={videoUrl} type={getMimeType(videoUrl)} />
         {subtitleUrl && (
           <track
             kind="subtitles"

--- a/src/renderer/global.d.ts
+++ b/src/renderer/global.d.ts
@@ -7,7 +7,7 @@ declare global {
         results: any[],
         videoFileName: string
       ) => Promise<{ success: boolean; path?: string }>;
-      getFilePath: (fileData: ArrayBuffer) => Promise<string>;
+      getFilePath: (fileData: ArrayBuffer, fileName: string) => Promise<string>;
       extractSubtitles: (videoPath: string) => Promise<{ success: boolean; content?: string; error?: string }>;
       getApiKey: () => Promise<string | null>;
       saveApiKey: (apiKey: string) => Promise<{ success: boolean }>;


### PR DESCRIPTION
## Summary
- allow uploading video formats other than mp4
- preserve original extension when saving temporary video files
- dynamically set MIME type for playback

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6868a37d779083239172ed17267aad3f