### PR TITLE
Adjust video clip offsets

### DIFF
--- a/src/renderer/components/VideoPlayer.tsx
+++ b/src/renderer/components/VideoPlayer.tsx
@@ -40,8 +40,8 @@ const VideoPlayer: React.FC<VideoPlayerProps> = ({
     playerRef.current = player;
 
     // Set up video segment
-    const startTime = Math.max(0, timestampToSeconds(beginTimestamp) - 1);
-    const endTime = timestampToSeconds(endTimestamp) + 1;
+    const startTime = Math.max(0, timestampToSeconds(beginTimestamp) - 2);
+    const endTime = timestampToSeconds(endTimestamp) + 2;
 
     player.ready(() => {
       player.currentTime(startTime);


### PR DESCRIPTION
## Summary
- extend the playback window around subtitle timestamps

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6868a93c0d2c8323bd67ddaf138b0064