### PR TITLE
Enable playback for MKV uploads

### DIFF
--- a/src/main/preload.js
+++ b/src/main/preload.js
@@ -3,7 +3,10 @@ const { contextBridge, ipcRenderer } = require('electron');
 contextBridge.exposeInMainWorld('electronAPI', {
   saveResults: (results, videoFileName) =>
     ipcRenderer.invoke('save-results', results, videoFileName),
-  getFilePath: (fileData) => ipcRenderer.invoke('get-file-path', fileData),
+  getFilePath: (fileData, fileName) =>
+    ipcRenderer.invoke('get-file-path', fileData, fileName),
+  convertVideo: (fileData, fileName) =>
+    ipcRenderer.invoke('convert-video', fileData, fileName),
   extractSubtitles: (videoPath) => ipcRenderer.invoke('extract-subtitles', videoPath),
   getApiKey: () => ipcRenderer.invoke('get-api-key'),
   saveApiKey: (apiKey) => ipcRenderer.invoke('save-api-key', apiKey),

--- a/src/renderer/global.d.ts
+++ b/src/renderer/global.d.ts
@@ -7,7 +7,11 @@ declare global {
         results: any[],
         videoFileName: string
       ) => Promise<{ success: boolean; path?: string }>;
-      getFilePath: (fileData: ArrayBuffer) => Promise<string>;
+      getFilePath: (fileData: ArrayBuffer, fileName: string) => Promise<string>;
+      convertVideo: (
+        fileData: ArrayBuffer,
+        fileName: string
+      ) => Promise<{ buffer: ArrayBuffer; mimeType: string }>;
       extractSubtitles: (videoPath: string) => Promise<{ success: boolean; content?: string; error?: string }>;
       getApiKey: () => Promise<string | null>;
       saveApiKey: (apiKey: string) => Promise<{ success: boolean }>;


### PR DESCRIPTION
## Summary
- add a new `convert-video` IPC handler that converts uploads to mp4
- expose `convertVideo` in the preload API and type declarations
- convert non-mp4 videos on upload so the player always receives mp4
- simplify `VideoPlayer` source element and remove `videoType` prop

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6868a37d779083239172ed17267aad3f