### PR TITLE
Add MKV file support

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -84,9 +84,9 @@ ipcMain.handle('save-results', async (_event, results, videoFileName) => {
   return { success: true, path: filePath };
 });
 
-ipcMain.handle('get-file-path', async (event, fileData) => {
-  // Save temporary file and return path for video player
-  const tempPath = path.join(app.getPath('temp'), `video-${Date.now()}.mp4`);
+ipcMain.handle('get-file-path', async (_event, fileData, fileName) => {
+  const ext = path.extname(fileName) || '.mp4';
+  const tempPath = path.join(app.getPath('temp'), `video-${Date.now()}${ext}`);
   fs.writeFileSync(tempPath, Buffer.from(fileData));
   return tempPath;
 });

--- a/src/main/preload.js
+++ b/src/main/preload.js
@@ -3,7 +3,8 @@ const { contextBridge, ipcRenderer } = require('electron');
 contextBridge.exposeInMainWorld('electronAPI', {
   saveResults: (results, videoFileName) =>
     ipcRenderer.invoke('save-results', results, videoFileName),
-  getFilePath: (fileData) => ipcRenderer.invoke('get-file-path', fileData),
+  getFilePath: (fileData, fileName) =>
+    ipcRenderer.invoke('get-file-path', fileData, fileName),
   extractSubtitles: (videoPath) => ipcRenderer.invoke('extract-subtitles', videoPath),
   getApiKey: () => ipcRenderer.invoke('get-api-key'),
   saveApiKey: (apiKey) => ipcRenderer.invoke('save-api-key', apiKey),

--- a/src/renderer/components/FileUpload.tsx
+++ b/src/renderer/components/FileUpload.tsx
@@ -37,7 +37,7 @@ const FileUpload: React.FC<FileUploadProps> = ({
       setVideoFile(file);
       // Create temporary file path for subtitle extraction
       const arrayBuffer = await file.arrayBuffer();
-      const filePath = await window.electronAPI.getFilePath(arrayBuffer);
+      const filePath = await window.electronAPI.getFilePath(arrayBuffer, file.name);
       videoFileRef.current = filePath;
       updateSessionData(file, subtitleFile, vocabularyWords);
     }
@@ -216,9 +216,9 @@ const FileUpload: React.FC<FileUploadProps> = ({
       <div className="upload-section">
         <div className="upload-item">
           <label>Video File (.mp4, .mkv, etc.)</label>
-          <input 
-            type="file" 
-            accept="video/*" 
+          <input
+            type="file"
+            accept=".mp4,.mkv,video/*"
             onChange={handleVideoUpload}
           />
           {videoFile && <span className="file-name">✓ {videoFile.name}</span>}

--- a/src/renderer/components/VideoPlayer.tsx
+++ b/src/renderer/components/VideoPlayer.tsx
@@ -5,6 +5,7 @@ import Player from 'video.js/dist/types/player';
 interface VideoPlayerProps {
   videoUrl: string;
   subtitleUrl: string;
+  videoType?: string;
   beginTimestamp: string;
   endTimestamp: string;
 }
@@ -12,6 +13,7 @@ interface VideoPlayerProps {
 const VideoPlayer: React.FC<VideoPlayerProps> = ({
   videoUrl,
   subtitleUrl,
+  videoType,
   beginTimestamp,
   endTimestamp
 }) => {
@@ -79,7 +81,7 @@ const VideoPlayer: React.FC<VideoPlayerProps> = ({
         className="video-js vjs-default-skin vjs-big-play-centered"
         playsInline
       >
-        <source src={videoUrl} type="video/mp4" />
+        <source src={videoUrl} {...(videoType ? { type: videoType } : {})} />
         {subtitleUrl && (
           <track
             kind="subtitles"

--- a/src/renderer/components/VocabularySession.tsx
+++ b/src/renderer/components/VocabularySession.tsx
@@ -119,6 +119,7 @@ const VocabularySession: React.FC<VocabularySessionProps> = ({
           <VideoPlayer
             videoUrl={videoUrl}
             subtitleUrl={subtitleUrl}
+            videoType={sessionData.videoFile.type}
             beginTimestamp={currentWord.beginTimestamp}
             endTimestamp={currentWord.endTimestamp}
             key={currentWord.term} // Force remount on word change

--- a/src/renderer/global.d.ts
+++ b/src/renderer/global.d.ts
@@ -7,7 +7,7 @@ declare global {
         results: any[],
         videoFileName: string
       ) => Promise<{ success: boolean; path?: string }>;
-      getFilePath: (fileData: ArrayBuffer) => Promise<string>;
+      getFilePath: (fileData: ArrayBuffer, fileName: string) => Promise<string>;
       extractSubtitles: (videoPath: string) => Promise<{ success: boolean; content?: string; error?: string }>;
       getApiKey: () => Promise<string | null>;
       saveApiKey: (apiKey: string) => Promise<{ success: boolean }>;


### PR DESCRIPTION
## Summary
- allow `.mkv` selection in upload form
- track video MIME type and use it when rendering
- support saving temp video files with the original extension

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6868b19acf448323acfb0237d1fc80d4