### PR TITLE
Add MKV upload and conversion

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "build:main": "tsc -p tsconfig.electron.json",
     "build": "npm run build:renderer && npm run build:main && npm run copy:preload && npm run copy:assets",
     "copy:preload": "cp src/main/preload.js dist/preload.js",
-    "copy:assets": "cp -r png dist/png",
+    "copy:assets": "cp -r png dist/png && cp src/main/progress.html dist/progress.html",
     "electron": "electron .",
     "dist": "npm run build && electron-builder"
   },

--- a/src/main/preload.js
+++ b/src/main/preload.js
@@ -3,10 +3,14 @@ const { contextBridge, ipcRenderer } = require('electron');
 contextBridge.exposeInMainWorld('electronAPI', {
   saveResults: (results, videoFileName) =>
     ipcRenderer.invoke('save-results', results, videoFileName),
-  getFilePath: (fileData) => ipcRenderer.invoke('get-file-path', fileData),
+  getFilePath: (fileData, ext) =>
+    ipcRenderer.invoke('get-file-path', fileData, ext),
   extractSubtitles: (videoPath) => ipcRenderer.invoke('extract-subtitles', videoPath),
   getApiKey: () => ipcRenderer.invoke('get-api-key'),
   saveApiKey: (apiKey) => ipcRenderer.invoke('save-api-key', apiKey),
   openExternal: (url) => ipcRenderer.invoke('open-external', url),
-  readFile: (filePath) => ipcRenderer.invoke('read-file', filePath)
+  readFile: (filePath) => ipcRenderer.invoke('read-file', filePath),
+  convertVideo: (inputPath, outputName) =>
+    ipcRenderer.invoke('convert-video', inputPath, outputName),
+  readBinaryFile: (filePath) => ipcRenderer.invoke('read-binary-file', filePath)
 });

--- a/src/main/progress.html
+++ b/src/main/progress.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <style>
+    body { background-color: #1a1a1a; color: #fff; font-family: Arial, sans-serif; margin: 0; padding: 20px; }
+    .progress-container { width: 100%; background: #444; border-radius: 5px; overflow: hidden; }
+    .progress-bar { height: 20px; width: 0%; background: #4caf50; transition: width 0.2s; }
+    .info { margin-top: 10px; text-align: center; }
+  </style>
+</head>
+<body>
+  <div class="progress-container"><div id="bar" class="progress-bar"></div></div>
+  <div id="info" class="info">Preparing...</div>
+  <script>
+    const { ipcRenderer } = require('electron');
+    ipcRenderer.on('conversion-progress', (_event, percent, remaining) => {
+      const bar = document.getElementById('bar');
+      const info = document.getElementById('info');
+      bar.style.width = percent + '%';
+      info.textContent = `Converting... ${percent.toFixed(1)}% (about ${remaining}s left)`;
+    });
+  </script>
+</body>
+</html>

--- a/src/renderer/components/VideoPlayer.tsx
+++ b/src/renderer/components/VideoPlayer.tsx
@@ -47,7 +47,7 @@ const VideoPlayer: React.FC<VideoPlayerProps> = ({
       player.currentTime(startTime);
       player.play();
 
-      const tracks = player.textTracks();
+      const tracks = player.textTracks() as any;
       for (let i = 0; i < tracks.length; i++) {
         tracks[i].mode = 'showing';
       }
@@ -84,7 +84,7 @@ const VideoPlayer: React.FC<VideoPlayerProps> = ({
           <track
             kind="subtitles"
             src={subtitleUrl}
-            srclang="en"
+            srcLang="en"
             label="English"
             default
           />

--- a/src/renderer/global.d.ts
+++ b/src/renderer/global.d.ts
@@ -7,12 +7,14 @@ declare global {
         results: any[],
         videoFileName: string
       ) => Promise<{ success: boolean; path?: string }>;
-      getFilePath: (fileData: ArrayBuffer) => Promise<string>;
+      getFilePath: (fileData: ArrayBuffer, ext: string) => Promise<string>;
       extractSubtitles: (videoPath: string) => Promise<{ success: boolean; content?: string; error?: string }>;
       getApiKey: () => Promise<string | null>;
       saveApiKey: (apiKey: string) => Promise<{ success: boolean }>;
       openExternal: (url: string) => Promise<{ success: boolean }>;
       readFile: (filePath: string) => Promise<{ success: boolean; content?: string; error?: string }>;
+      convertVideo: (inputPath: string, outputName: string) => Promise<{ success: boolean; outputPath?: string; error?: string }>;
+      readBinaryFile: (filePath: string) => Promise<{ success: boolean; data?: ArrayBuffer; error?: string }>;
     };
   }
 }


### PR DESCRIPTION
## Summary
- allow saving file paths with extension
- implement MKV->MP4 conversion with progress window
- expose conversion APIs in preload and type defs
- read converted binary to create File in renderer
- copy progress window in build

## Testing
- `npm install`
- `npm run build:main`
- `npx tsc -p tsconfig.json`


------
https://chatgpt.com/codex/tasks/task_e_6868b60094f88323935b9745b102cd6d