### PR TITLE
Add Makefile for easy install/build/start

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,13 @@
+run: install build start
+
+install:
+	npm install
+
+build:
+	npm run build
+
+start:
+	npm start
+
+.PHONY: run install build start
+

--- a/README.md
+++ b/README.md
@@ -52,6 +52,15 @@ npm start            # launches the compiled app
 npm run dist         # uses electron-builder
 ```
 
+### Run everything with Make
+
+Instead of manually running the install, build and start commands,
+you can also use the provided Makefile:
+
+```bash
+make run            # runs npm install, npm run build and npm start
+```
+
 The macOS bundle will appear under **dist/**.
 
 ---


### PR DESCRIPTION
## Summary
- add Makefile with `run` target to install deps, build and start app
- document Makefile usage in README

## Testing
- `make -n run`

------
https://chatgpt.com/codex/tasks/task_e_6868c192ce548323a4f26a39f79675c5