### PR TITLE
Fix saving of unknown word list

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import FileUpload from './components/FileUpload';
 import VocabularySession from './components/VocabularySession';
-import { SessionData } from './types';
+import { SessionData, WordResult } from './types';
 
 const App: React.FC = () => {
   const [sessionData, setSessionData] = useState<SessionData | null>(null);
@@ -17,10 +17,10 @@ const App: React.FC = () => {
     }
   };
 
-  const handleSessionComplete = async (results: any[]) => {
-    // Filter out known words
+  const handleSessionComplete = async (results: WordResult[]) => {
+    // Collect words the user ever marked as unknown
     const unknownWords = results
-      .filter(result => !result.known)
+      .filter(result => result.wasUnknown)
       .map(result => result.word);
 
     // Save results

--- a/src/renderer/components/VocabularySession.tsx
+++ b/src/renderer/components/VocabularySession.tsx
@@ -75,19 +75,26 @@ const VocabularySession: React.FC<VocabularySessionProps> = ({
   };
   
   const handleResponse = (known: boolean) => {
-    const newResult: WordResult = {
-      word: currentWord,
-      known
-    };
-
-    // Update or add result
     const existingIndex = results.findIndex(r => r.word.term === currentWord.term);
+
+    const updatedResult: WordResult = existingIndex >= 0
+      ? {
+          word: currentWord,
+          known,
+          wasUnknown: results[existingIndex].wasUnknown || !known
+        }
+      : {
+          word: currentWord,
+          known,
+          wasUnknown: !known
+        };
+
     if (existingIndex >= 0) {
       const newResults = [...results];
-      newResults[existingIndex] = newResult;
+      newResults[existingIndex] = updatedResult;
       setResults(newResults);
     } else {
-      setResults([...results, newResult]);
+      setResults([...results, updatedResult]);
     }
 
     if (!known) {

--- a/src/renderer/types/index.ts
+++ b/src/renderer/types/index.ts
@@ -19,4 +19,6 @@ export interface SessionData {
 export interface WordResult {
   word: VocabularyWord;
   known: boolean;
+  /** Whether the user ever marked this word as unknown */
+  wasUnknown: boolean;
 }


### PR DESCRIPTION
## Summary
- mark if a word has ever been answered as unknown
- persist these markers during the session
- save all words ever marked unknown when finishing the session

## Testing
- `npm run build:main`
- `npm run build:renderer`


------
https://chatgpt.com/codex/tasks/task_e_686909fad0508323aafde8a08c3a0f7b