### PR TITLE
Add subtitle offset slider

### DIFF
--- a/src/renderer/components/VideoPlayer.tsx
+++ b/src/renderer/components/VideoPlayer.tsx
@@ -14,6 +14,8 @@ interface VideoPlayerProps {
   showAudioButton?: boolean;
   /** Callback when user requests audio generation */
   onRequestAudio?: () => void;
+  /** Offset to apply to begin/end timestamps */
+  offset?: number;
 }
 
 const VideoPlayer: React.FC<VideoPlayerProps> = ({
@@ -24,7 +26,8 @@ const VideoPlayer: React.FC<VideoPlayerProps> = ({
   videoFileName = '',
   externalAudio,
   showAudioButton,
-  onRequestAudio
+  onRequestAudio,
+  offset = 0
 }) => {
   const videoRef = useRef<HTMLVideoElement>(null);
   const playerRef = useRef<Player | null>(null);
@@ -78,8 +81,11 @@ const VideoPlayer: React.FC<VideoPlayerProps> = ({
     }
 
     // Set up video segment
-    const startTime = Math.max(0, timestampToSeconds(beginTimestamp) - 2);
-    const endTime = timestampToSeconds(endTimestamp) + 2;
+    const startTime = Math.max(
+      0,
+      timestampToSeconds(beginTimestamp) + offset - 2
+    );
+    const endTime = timestampToSeconds(endTimestamp) + offset + 2;
 
     player.ready(() => {
       player.currentTime(startTime);
@@ -123,7 +129,7 @@ const VideoPlayer: React.FC<VideoPlayerProps> = ({
         playerRef.current = null;
       }
     };
-  }, [videoUrl, beginTimestamp, endTimestamp, videoFileName, externalAudio]);
+  }, [videoUrl, beginTimestamp, endTimestamp, videoFileName, externalAudio, offset]);
 
   const mimeType = getMimeType(videoFileName);
 

--- a/src/renderer/components/VocabularySession.tsx
+++ b/src/renderer/components/VocabularySession.tsx
@@ -18,6 +18,8 @@ const VocabularySession: React.FC<VocabularySessionProps> = ({
   const [subtitleUrl, setSubtitleUrl] = useState<string>('');
   const [audioReady, setAudioReady] = useState(false);
   const audioRef = React.useRef<HTMLAudioElement | null>(null);
+  const [offset, setOffset] = useState(0);
+  const [showOffsetControl, setShowOffsetControl] = useState(false);
 
   useEffect(() => {
     // Create object URL for video file
@@ -158,8 +160,30 @@ const VocabularySession: React.FC<VocabularySessionProps> = ({
             externalAudio={audioRef.current || undefined}
             showAudioButton={currentIndex === 0 && !audioReady}
             onRequestAudio={handleGenerateAudio}
+            offset={offset}
             key={currentWord.term} // Force remount on word change
           />
+          <div className="offset-controls">
+            {showOffsetControl && (
+              <div className="offset-slider">
+                <input
+                  type="range"
+                  min="-10"
+                  max="10"
+                  step="0.5"
+                  value={offset}
+                  onChange={e => setOffset(parseFloat(e.target.value))}
+                />
+                <span className="offset-label">{offset >= 0 ? `+${offset}` : offset} s</span>
+              </div>
+            )}
+            <button
+              className="options-btn"
+              onClick={() => setShowOffsetControl(!showOffsetControl)}
+            >
+              ⚙️
+            </button>
+          </div>
         </div>
 
         <div className="word-info-section">

--- a/src/renderer/styles/main.css
+++ b/src/renderer/styles/main.css
@@ -304,6 +304,7 @@ body {
   align-items: center;
   justify-content: center;
   padding: 20px;
+  position: relative;
 }
 
 .video-player-wrapper {
@@ -324,6 +325,46 @@ body {
   border-radius: 4px;
   cursor: pointer;
   font-size: 1rem;
+}
+
+.offset-controls {
+  position: absolute;
+  bottom: 10px;
+  left: 10px;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  z-index: 10;
+}
+
+.options-btn {
+  background: rgba(0, 0, 0, 0.6);
+  border: none;
+  color: #fff;
+  padding: 6px 10px;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 1rem;
+}
+
+.offset-slider {
+  display: flex;
+  align-items: center;
+  background: rgba(0, 0, 0, 0.6);
+  padding: 5px;
+  border-radius: 4px;
+}
+
+.offset-slider input[type="range"] {
+  width: 150px;
+  margin-right: 8px;
+}
+
+.offset-label {
+  color: #fff;
+  font-size: 0.9rem;
+  min-width: 40px;
+  text-align: center;
 }
 
 .word-info-section {


### PR DESCRIPTION
## Summary
- add optional offset prop to VideoPlayer and apply to playback timing
- persist offset setting in VocabularySession
- show gear icon and range slider to shift subtitles ±10s
- style new controls and make video section position relative

## Testing
- `npm run build`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688975b24964832383082e10b50919fb