### PR TITLE
Add subtitle offset slider

### DIFF
--- a/src/renderer/components/VideoPlayer.tsx
+++ b/src/renderer/components/VideoPlayer.tsx
@@ -14,6 +14,8 @@ interface VideoPlayerProps {
   showAudioButton?: boolean;
   /** Callback when user requests audio generation */
   onRequestAudio?: () => void;
+  /** Offset to apply to begin/end timestamps */
+  offset?: number;
 }
 
 const VideoPlayer: React.FC<VideoPlayerProps> = ({
@@ -24,7 +26,8 @@ const VideoPlayer: React.FC<VideoPlayerProps> = ({
   videoFileName = '',
   externalAudio,
   showAudioButton,
-  onRequestAudio
+  onRequestAudio,
+  offset = 0
 }) => {
   const videoRef = useRef<HTMLVideoElement>(null);
   const playerRef = useRef<Player | null>(null);
@@ -78,8 +81,11 @@ const VideoPlayer: React.FC<VideoPlayerProps> = ({
     }
 
     // Set up video segment
-    const startTime = Math.max(0, timestampToSeconds(beginTimestamp) - 2);
-    const endTime = timestampToSeconds(endTimestamp) + 2;
+    const startTime = Math.max(
+      0,
+      timestampToSeconds(beginTimestamp) + offset - 2
+    );
+    const endTime = timestampToSeconds(endTimestamp) + offset + 2;
 
     player.ready(() => {
       player.currentTime(startTime);
@@ -123,7 +129,7 @@ const VideoPlayer: React.FC<VideoPlayerProps> = ({
         playerRef.current = null;
       }
     };
-  }, [videoUrl, beginTimestamp, endTimestamp, videoFileName, externalAudio]);
+  }, [videoUrl, beginTimestamp, endTimestamp, videoFileName, externalAudio, offset]);
 
   const mimeType = getMimeType(videoFileName);
 

--- a/src/renderer/styles/main.css
+++ b/src/renderer/styles/main.css
@@ -304,6 +304,7 @@ body {
   align-items: center;
   justify-content: center;
   padding: 20px;
+  position: relative;
 }
 
 .video-player-wrapper {
@@ -324,6 +325,46 @@ body {
   border-radius: 4px;
   cursor: pointer;
   font-size: 1rem;
+}
+
+.offset-controls {
+  position: absolute;
+  bottom: 10px;
+  left: 10px;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  z-index: 10;
+}
+
+.options-btn {
+  background: rgba(0, 0, 0, 0.6);
+  border: none;
+  color: #fff;
+  padding: 6px 10px;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 1rem;
+}
+
+.offset-slider {
+  display: flex;
+  align-items: center;
+  background: rgba(0, 0, 0, 0.6);
+  padding: 5px;
+  border-radius: 4px;
+}
+
+.offset-slider input[type="range"] {
+  width: 200px;
+  margin-right: 8px;
+}
+
+.offset-label {
+  color: #fff;
+  font-size: 0.9rem;
+  min-width: 40px;
+  text-align: center;
 }
 
 .word-info-section {


### PR DESCRIPTION
## Summary
- make slider range ±30 and display selected offset with one decimal
- regenerate VTT subtitles with offset so video and subtitles remain synced
- expand slider width for easier adjustment

## Testing
- `npm run build`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688975b24964832383082e10b50919fb