### PR TITLE
Use uploaded video when generating background audio

### DIFF
--- a/src/main/preload.js
+++ b/src/main/preload.js
@@ -9,5 +9,5 @@ contextBridge.exposeInMainWorld('electronAPI', {
   saveApiKey: (apiKey) => ipcRenderer.invoke('save-api-key', apiKey),
   openExternal: (url) => ipcRenderer.invoke('open-external', url),
   readFile: (filePath) => ipcRenderer.invoke('read-file', filePath),
-  convertToMp3: (videoPath) => ipcRenderer.invoke('convert-to-mp3', videoPath)
+  convertToMp3: (source) => ipcRenderer.invoke('convert-to-mp3', source)
 });

--- a/src/renderer/components/VocabularySession.tsx
+++ b/src/renderer/components/VocabularySession.tsx
@@ -95,7 +95,12 @@ const VocabularySession: React.FC<VocabularySessionProps> = ({
 
   const handleGenerateAudio = async () => {
     try {
-      const result = await window.electronAPI.convertToMp3(sessionData.videoFilePath);
+      const fileData = await sessionData.videoFile.arrayBuffer();
+      const result = await window.electronAPI.convertToMp3({
+        filePath: sessionData.videoFilePath,
+        fileName: sessionData.videoFile.name,
+        data: fileData
+      });
       if (result.success && result.path) {
         const url = 'file://' + result.path;
         audioRef.current = new Audio(url);

--- a/src/renderer/global.d.ts
+++ b/src/renderer/global.d.ts
@@ -13,7 +13,15 @@ declare global {
       saveApiKey: (apiKey: string) => Promise<{ success: boolean }>;
       openExternal: (url: string) => Promise<{ success: boolean }>;
       readFile: (filePath: string) => Promise<{ success: boolean; content?: string; error?: string }>;
-      convertToMp3: (videoPath: string) => Promise<{ success: boolean; path?: string; error?: string }>;
+      convertToMp3: (
+        source:
+          | string
+          | {
+              filePath?: string;
+              data?: ArrayBuffer;
+              fileName?: string;
+            }
+      ) => Promise<{ success: boolean; path?: string; error?: string }>;
     };
   }
 }


### PR DESCRIPTION
## Summary
- allow the convert-to-mp3 IPC handler to work with either a file path or binary data from the uploaded video and clean up temp files after conversion
- update the renderer to send the selected video file to the main process so audio generation no longer requires a manual copy in the project root
- refresh the preload bridge and TypeScript definitions to reflect the new conversion source signature

## Testing
- npm run build:main
- npm run build:renderer

------
https://chatgpt.com/codex/tasks/task_e_68d0b997ddac8323b2413e6fb9d192e8