### PR TITLE
Use uploaded video when generating mp3 audio

### DIFF
--- a/src/main/preload.js
+++ b/src/main/preload.js
@@ -9,5 +9,5 @@ contextBridge.exposeInMainWorld('electronAPI', {
   saveApiKey: (apiKey) => ipcRenderer.invoke('save-api-key', apiKey),
   openExternal: (url) => ipcRenderer.invoke('open-external', url),
   readFile: (filePath) => ipcRenderer.invoke('read-file', filePath),
-  convertToMp3: (videoPath) => ipcRenderer.invoke('convert-to-mp3', videoPath)
+  convertToMp3: (options) => ipcRenderer.invoke('convert-to-mp3', options)
 });

--- a/src/renderer/global.d.ts
+++ b/src/renderer/global.d.ts
@@ -13,7 +13,15 @@ declare global {
       saveApiKey: (apiKey: string) => Promise<{ success: boolean }>;
       openExternal: (url: string) => Promise<{ success: boolean }>;
       readFile: (filePath: string) => Promise<{ success: boolean; content?: string; error?: string }>;
-      convertToMp3: (videoPath: string) => Promise<{ success: boolean; path?: string; error?: string }>;
+      convertToMp3: (
+        options:
+          | string
+          | {
+              videoPath?: string;
+              originalFileName?: string;
+              videoData?: Uint8Array | ArrayBuffer;
+            }
+      ) => Promise<{ success: boolean; path?: string; error?: string }>;
     };
   }
 }


### PR DESCRIPTION
## Summary
- allow the renderer to request MP3 conversion with either a saved path or the uploaded video bytes
- update the main process to persist temporary copies of the uploaded video, clean them up, and continue naming audio after the source file
- refresh preload typings so the renderer can send structured options when triggering conversion

## Testing
- npm run build:renderer
- npm run build:main

------
https://chatgpt.com/codex/tasks/task_e_68d0b997ddac8323b2413e6fb9d192e8